### PR TITLE
Use \DeclarePairedDelimiter instead of \def to define ceil and floor.

### DIFF
--- a/math_commands.tex
+++ b/math_commands.tex
@@ -1,6 +1,6 @@
 %%%%% NEW MATH DEFINITIONS %%%%%
 
-\usepackage{amsmath,amsfonts,bm}
+\usepackage{amsmath,amsfonts,bm,mathtools}
 
 % Mark sections of captions for referring to divisions of figures
 \newcommand{\figleft}{{\em (Left)}}
@@ -55,8 +55,8 @@
 \def\Partref#1{Part~\ref{#1}}
 \def\twopartref#1#2{parts \ref{#1} and \ref{#2}}
 
-\def\ceil#1{\lceil #1 \rceil}
-\def\floor#1{\lfloor #1 \rfloor}
+\DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
+\DeclarePairedDelimiter{\floor}{\lfloor}{\rfloor}
 \def\1{\bm{1}}
 \newcommand{\train}{\mathcal{D}}
 \newcommand{\valid}{\mathcal{D_{\mathrm{valid}}}}


### PR DESCRIPTION
Using \DeclarePairedDelimiter offers much more benefit such as auto scaling of the paired operator.
See

https://tex.stackexchange.com/questions/94410/easily-change-behavior-of-declarepaireddelimiter

for some examples.

---

Aside from that, I highly suggest adding a license for these files -- [no explicit license essentially means propriety](https://www.gnu.org/licenses/license-list.en.html#NoLicense). If you like public domain, you can try [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/)...